### PR TITLE
[2022.11.13] 프로젝트 리스트 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sa-ux-test-client",
-      "version": "0.3.2",
+      "version": "0.4.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -18,6 +18,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.6.0",
+        "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.6"
       },
@@ -3745,6 +3746,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -15137,6 +15146,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -20668,6 +20707,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@remix-run/router": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.3.tgz",
+      "integrity": "sha512-ceuyTSs7PZ/tQqi19YZNBc5X7kj1f8p+4DIyrcIYFY9h+hd1OKm4RqtiWldR9eGEvIiJfsqwM4BsuCtRIuEw6Q=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -28834,6 +28878,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.3.tgz",
+      "integrity": "sha512-BT6DoGn6aV1FVP5yfODMOiieakp3z46P1Fk0RNzJMACzE7C339sFuHebfvWtnB4pzBvXXkHP2vscJzWRuUjTtA==",
+      "requires": {
+        "@remix-run/router": "1.0.3"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.3.tgz",
+      "integrity": "sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==",
+      "requires": {
+        "@remix-run/router": "1.0.3",
+        "react-router": "6.4.3"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-client.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.6.0",
+    "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6"
   },

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,11 +1,14 @@
 import React from "react";
+import { Route, Routes } from "react-router-dom";
 import Main from "../pages/Main";
+import Projects from "../pages/Projects";
 
 const App = () => {
   return (
-    <>
-      <Main />
-    </>
+    <Routes>
+      <Route path="/" element={<Main />} />
+      <Route path="/Projects" element={<Projects />} />
+    </Routes>
   );
 };
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { signInWithPopup } from "firebase/auth";
 import { auth, provider } from "../../config/firebase";
 import axios from "axios";
@@ -6,7 +7,21 @@ import { DOMAIN } from "../../config/domain";
 import styled from "styled-components";
 
 const Header = () => {
+  const navigate = useNavigate();
+
+  const user = localStorage.getItem("name");
+
+  let userName = "";
+
+  if (user) {
+    userName = user.replace(/"/g, "");
+  }
+
   const handleLogin = async () => {
+    if (userName) {
+      return;
+    }
+
     try {
       const signInUser = await signInWithPopup(auth, provider);
       const { user } = signInUser;
@@ -25,7 +40,8 @@ const Header = () => {
         },
       );
 
-      localStorage.setItem("token", JSON.stringify(response.data.user.name));
+      localStorage.setItem("name", JSON.stringify(response.data.user.name));
+      navigate("/Projects");
     } catch (error) {
       console.error(error);
     }
@@ -35,7 +51,14 @@ const Header = () => {
     <Wrapper>
       <HeaderImg src="/images/sa.png" alt="logo" />
       <h2>SA-UX-TEST</h2>
-      <LoginButton onClick={handleLogin}>로그인</LoginButton>
+      <HeaderButton>
+        <LoginButton onClick={handleLogin}>
+          {userName ? userName : "로그인"}
+        </LoginButton>
+        {userName && (
+          <LogoutButton onClick={handleLogin}>로그아웃</LogoutButton>
+        )}
+      </HeaderButton>
     </Wrapper>
   );
 };
@@ -44,8 +67,8 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.6rem;
   margin: 0.6rem;
+  padding: 0.6rem;
   border-bottom: 0.1rem solid black;
 `;
 
@@ -55,7 +78,19 @@ const HeaderImg = styled.img`
   margin-left: 1rem;
 `;
 
+const HeaderButton = styled.div`
+  display: flex;
+`;
+
 const LoginButton = styled.button`
+  margin-right: 2rem;
+  border-style: none;
+  font-size: 1rem;
+  cursor: pointer;
+  background-color: transparent;
+`;
+
+const LogoutButton = styled.button`
   margin-right: 2rem;
   border-style: none;
   font-size: 1rem;

--- a/src/components/Main/Content.js
+++ b/src/components/Main/Content.js
@@ -8,19 +8,19 @@ const Content = () => {
       <HeadText>실제 사용자의 모든 데이터를 한눈에 확인하세요.</HeadText>
       <CheckList>
         <List>
-          <FiCheck color="#f67280" /> 방문 횟수
+          <FiCheck className="icon" /> 방문 횟수
         </List>
         <List>
-          <FiCheck color="#f67280" /> 평균 이용 시간
+          <FiCheck className="icon" /> 평균 이용 시간
         </List>
         <List>
-          <FiCheck color="#f67280" /> 유입된 이전 사이트
+          <FiCheck className="icon" /> 유입된 이전 사이트
         </List>
         <List>
-          <FiCheck color="#f67280" /> 마우스의 움직임(move, hover, click)
+          <FiCheck className="icon" /> 마우스의 움직임(move, hover, click)
         </List>
         <List>
-          <FiCheck color="#f67280" /> 이용 화면 녹화
+          <FiCheck className="icon" /> 이용 화면 녹화
         </List>
       </CheckList>
     </Wrapper>
@@ -31,8 +31,8 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   text-align: center;
-  height: 100vh;
   width: 100vw;
+  height: 100vh;
   background-image: url("/images/ux-test.png");
   background-repeat: no-repeat;
   background-position: center;
@@ -53,6 +53,10 @@ const CheckList = styled.div`
 const List = styled.div`
   margin: 0.8rem;
   font-size: 1.5rem;
+
+  .icon {
+    color: #f67280;
+  }
 `;
 
 export default Content;

--- a/src/components/Projects/ProjectLists.js
+++ b/src/components/Projects/ProjectLists.js
@@ -1,0 +1,52 @@
+import React from "react";
+import styled from "styled-components";
+
+const ProjectLists = () => {
+  return (
+    <Wrapper>
+      <ContentsList>
+        <Title>Project Name</Title>
+        <Content>UX-TEST</Content>
+      </ContentsList>
+      <ContentsList>
+        <Title>Project Url</Title>
+        <Content>https://www.sa-ux-test.com</Content>
+      </ContentsList>
+      <ContentsList>
+        <Title>Script Tag</Title>
+        <Content>
+          type=text/javascript
+          src=http://localhost:8080/tests/ux-test?key=a1b2c3
+        </Content>
+      </ContentsList>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 50vmin;
+  height: 30vmin;
+  margin: 2rem;
+  padding: 1rem;
+  border-radius: 2rem;
+  box-shadow: 0 1px 6px 0 #c0c0c0;
+`;
+
+const ContentsList = styled.div`
+  margin: 0.4rem;
+`;
+
+const Title = styled.div`
+  margin-bottom: 0.2rem;
+  font-size: 1.4rem;
+  color: #c0c0c0;
+`;
+
+const Content = styled.div`
+  font-size: 0.8rem;
+  color: #585858;
+`;
+
+export default ProjectLists;

--- a/src/components/Projects/TotalProject.js
+++ b/src/components/Projects/TotalProject.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { GrAddCircle } from "react-icons/gr";
+import styled from "styled-components";
+
+const TotalProject = () => {
+  return (
+    <Wrapper>
+      <ProjectAdd>
+        <GrAddCircle /> NEW PROJECT
+      </ProjectAdd>
+      <ProjectCount>
+        <Text>TotalProject</Text>
+        <Number>1</Number>
+      </ProjectCount>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  margin: 0 2rem;
+`;
+
+const ProjectAdd = styled.div`
+  display: flex;
+  align-items: center;
+  width: 20vmin;
+  height: 5vmin;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border: 0.1rem solid #c0c0c0;
+  border-radius: 2rem;
+  font-size: 0.8rem;
+  color: #585858;
+`;
+
+const ProjectCount = styled.div`
+  display: inline-block;
+  flex-direction: column;
+  width: 20vmin;
+  padding: 1.4rem;
+  border: 0.1rem solid #c0c0c0;
+  border-radius: 2rem;
+`;
+
+const Text = styled.div`
+  font-size: 0.8rem;
+  color: #c0c0c0;
+`;
+
+const Number = styled.div`
+  color: #585858;
+`;
+
+export default TotalProject;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter as Router } from "react-router-dom";
 import GlobalStyle from "./shared/GlobalStyle";
 import App from "./app/App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  <React.StrictMode>
+  <Router>
     <GlobalStyle />
     <App />
-  </React.StrictMode>,
+  </Router>,
 );

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,6 +1,6 @@
 import React from "react";
-import Content from "../components/Main/Content";
 import Header from "../components/Header/Header";
+import Content from "../components/Main/Content";
 
 const Main = () => {
   return (

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header/Header";
+import TotalProject from "../components/Projects/TotalProject";
+import ProjectLists from "../components/Projects/ProjectLists";
+
+const Projects = () => {
+  return (
+    <>
+      <Header />
+      <TotalProject />
+      <ProjectLists />
+    </>
+  );
+};
+
+export default Projects;


### PR DESCRIPTION
<img width="1510" alt="스크린샷 2022-11-13 오후 1 31 33" src="https://user-images.githubusercontent.com/89302818/201506708-46e532c9-a58f-47d8-8bf4-a27a59ce02a7.png">

# Topic
- 프로젝트 리스트 페이지 구현

# Detail
- 프로젝트 리스트 페이지 레이아웃 구현

# Kanban Link
- https://shaded-calculator-f57.notion.site/Layout-f4f22edb5b0046d6986705543c8e5a8a

# Kanban List
- [x]  프로젝트 생성 버튼 만들기
- [x]  전체 프로젝트 갯수 보여질 수 있도록 하기
- [x]  생성된 프로젝트 리스트 보여주기
