### PR TITLE
[2022.11.20] 통계페이지 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.9.7",
+  "version": "0.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sa-ux-test-client",
-      "version": "0.9.7",
+      "version": "0.10.6",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.9.7",
+  "version": "0.10.6",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-client.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",

--- a/src/components/Statics/Graph.js
+++ b/src/components/Statics/Graph.js
@@ -1,26 +1,35 @@
 import React from "react";
 import Visit from "./Visit";
-import Time from "./Time";
 import Site from "./Site";
+import Time from "./Time";
 import Keyword from "./Keyword";
 import Tag from "./Tag";
 import styled from "styled-components";
+import PropTypes from "prop-types";
 
-const Graph = () => {
+const Graph = ({
+  visitData,
+  timeData,
+  siteData,
+  keywordKeys,
+  keywordValues,
+  tagKeys,
+  tagValues,
+}) => {
   return (
     <Wrapper>
       <Left>
         <Card>
-          <Visit />
-          <Time />
+          <Visit visitData={visitData} />
+          <Time timeData={timeData} />
         </Card>
         <Chart>
-          <Site />
+          <Site siteData={siteData} />
         </Chart>
       </Left>
       <Right>
-        <Keyword />
-        <Tag />
+        <Keyword keywordKeys={keywordKeys} keywordValues={keywordValues} />
+        <Tag tagKeys={tagKeys} tagValues={tagValues} />
       </Right>
     </Wrapper>
   );
@@ -33,9 +42,9 @@ const Wrapper = styled.div`
 
 const Left = styled.div`
   display: flex;
-  float: left;
   flex-direction: column;
   align-items: center;
+  float: left;
   width: 40%;
 `;
 
@@ -43,7 +52,6 @@ const Card = styled.div`
   display: flex;
   margin-bottom: 3rem;
 `;
-
 const Chart = styled.div`
   margin-left: 3rem;
 `;
@@ -52,8 +60,12 @@ const Right = styled.div`
   display: flex;
   float: right;
   justify-content: space-evenly;
-  width: 60%;
   margin-top: 2rem;
+  width: 60%;
 `;
+
+Graph.propTypes = {
+  staticData: PropTypes.number,
+};
 
 export default Graph;

--- a/src/components/Statics/Keyword.js
+++ b/src/components/Statics/Keyword.js
@@ -3,12 +3,22 @@ import { Pie } from "react-chartjs-2";
 import { Chart as ChartJS } from "chart.js/auto";
 import styled from "styled-components";
 
-const Keyword = () => {
+const Keyword = ({ keywordKeys, keywordValues }) => {
+  // const keywordList = clickData.map((data) => JSON.parse(data.context));
+  // const counts = keywordList.reduce((name, count) => {
+  //   name[count] = (name[count] || 0) + 1;
+  //   return name;
+  // }, {});
+
+  // const keys = Object.keys(counts);
+  // const values = Object.values(counts);
+  // console.log(keys);
+
   const data = {
-    labels: [1, 2, 3, 4, 5],
+    labels: keywordKeys.map((key) => key),
     datasets: [
       {
-        data: [1, 2, 3, 4, 5],
+        data: keywordValues.map((value) => value),
         backgroundColor: [
           "rgba(255, 99, 132, 0.2)",
           "rgba(255, 159, 64, 0.2)",
@@ -48,9 +58,9 @@ const Wrapper = styled.div`
 
 const Title = styled.div`
   text-align: center;
+  color: #ffffff;
   border-radius: 0.2rem;
   background-color: #faa0a0;
-  color: #ffffff;
 `;
 
 export default Keyword;

--- a/src/components/Statics/Site.js
+++ b/src/components/Statics/Site.js
@@ -3,12 +3,20 @@ import { Bar } from "react-chartjs-2";
 import { Chart as ChartJS } from "chart.js/auto";
 import styled from "styled-components";
 
-const Site = () => {
+const Site = ({ siteData }) => {
+  const counts = siteData.reduce((name, count) => {
+    name[count] = (name[count] || 0) + 1;
+    return name;
+  }, {});
+
+  const keys = Object.keys(counts);
+  const values = Object.values(counts);
+
   const data = {
-    labels: [1, 2, 3, 4, 5],
+    labels: keys.map((site) => site),
     datasets: [
       {
-        data: [1, 2, 3, 4, 5],
+        data: values.map((site) => site),
         backgroundColor: [
           "rgba(255, 99, 132, 0.2)",
           "rgba(255, 159, 64, 0.2)",
@@ -49,9 +57,9 @@ const Wrapper = styled.div`
 
 const Title = styled.div`
   text-align: center;
+  color: #ffffff;
   border-radius: 0.2rem;
   background-color: #faa0a0;
-  color: #ffffff;
 `;
 
 export default Site;

--- a/src/components/Statics/Tag.js
+++ b/src/components/Statics/Tag.js
@@ -3,12 +3,21 @@ import { Pie } from "react-chartjs-2";
 import { Chart as ChartJS } from "chart.js/auto";
 import styled from "styled-components";
 
-const Tag = () => {
+const Tag = ({ tagKeys, tagValues }) => {
+  // const tagList = clickData.map((data) => JSON.parse(data.tag));
+  // const counts = tagList.reduce((name, count) => {
+  //   name[count] = (name[count] || 0) + 1;
+  //   return name;
+  // }, {});
+
+  // const keys = Object.keys(counts);
+  // const values = Object.values(counts);
+
   const data = {
-    labels: [1, 2, 3, 4, 5],
+    labels: tagKeys.map((key) => key),
     datasets: [
       {
-        data: [1, 2, 3, 4, 5],
+        data: tagValues.map((value) => value),
         backgroundColor: [
           "rgba(255, 99, 132, 0.2)",
           "rgba(255, 159, 64, 0.2)",
@@ -47,9 +56,9 @@ const Wrapper = styled.div`
 
 const Title = styled.div`
   text-align: center;
+  color: #ffffff;
   border-radius: 0.2rem;
   background-color: #faa0a0;
-  color: #ffffff;
 `;
 
 export default Tag;

--- a/src/components/Statics/Time.js
+++ b/src/components/Statics/Time.js
@@ -2,14 +2,18 @@ import React from "react";
 import styled from "styled-components";
 import { GiPlayerTime } from "react-icons/gi";
 
-const Time = () => {
+const Time = ({ timeData }) => {
+  const time =
+    new Date(timeData.disconnectTime) - new Date(timeData.connectTime);
+  const average = Math.ceil(time / 1000 / 60);
+
   return (
     <Wrapper>
       <Title>
         <GiPlayerTime className="icon" />
         <div>Average Time</div>
       </Title>
-      <Content>10분</Content>
+      <Content>{average}분</Content>
     </Wrapper>
   );
 };
@@ -30,15 +34,15 @@ const Title = styled.div`
   margin: 1rem;
 
   .icon {
-    margin-right: 1rem;
     font-size: 2rem;
+    margin-right: 1rem;
     color: rgb(160, 160, 160);
   }
 `;
 
 const Content = styled.div`
-  text-align: center;
   margin: 1rem;
+  text-align: center;
   font-size: 2rem;
   color: #f67280;
 `;

--- a/src/components/Statics/Visit.js
+++ b/src/components/Statics/Visit.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { FaHouseUser } from "react-icons/fa";
 import styled from "styled-components";
+import PropTypes from "prop-types";
 
-const Visit = () => {
+const Visit = ({ visitData }) => {
   return (
     <Wrapper>
       <Title>
@@ -10,7 +11,7 @@ const Visit = () => {
         <div>Total Visit</div>
       </Title>
       <Content>
-        <div>1명</div>
+        <div>{visitData}명</div>
       </Content>
     </Wrapper>
   );
@@ -19,8 +20,8 @@ const Visit = () => {
 const Wrapper = styled.div`
   width: 25vmin;
   height: 15vmin;
-  margin-right: 2rem;
   padding: 0.4rem;
+  margin-right: 2rem;
   -webkit-box-shadow: 2px 4px 10px 1px rgba(0, 0, 0, 0.47);
   box-shadow: 2px 4px 10px 1px rgba(201, 201, 201, 0.47);
   border-radius: 10px;
@@ -33,17 +34,21 @@ const Title = styled.div`
   margin: 1rem;
 
   .icon {
-    margin-right: 1rem;
     font-size: 2rem;
+    margin-right: 1rem;
     color: rgb(160, 160, 160);
   }
 `;
 
 const Content = styled.div`
-  text-align: center;
   margin: 1rem;
+  text-align: center;
   font-size: 2rem;
   color: #f67280;
 `;
+
+Visit.propTypes = {
+  visitData: PropTypes.number,
+};
 
 export default Visit;


### PR DESCRIPTION
<img width="1512" alt="통계페이지 기능구현" src="https://user-images.githubusercontent.com/89302818/202892751-295e2ad2-09df-421c-a59d-9cd06b698d22.png">

# Topic
- 통계 페이지 기능 구현

# Detail
- 전체 방문자 통계 데이터
- 방문자 평균 이용 시간
- 이전 사이트 방문 기록
- 클릭한 키워드 통계 데이터
- 클릭한 태그 통계 데이터

# Kanban Link
- https://shaded-calculator-f57.notion.site/Feature-8403891ee06f46518b965c559d94d0ee

# Kanban List
- [x]  방문횟수 그래프 만들기 ⇒ 카드 형태로 변경
- [x]  이용시간 그래프 만들기 ⇒ 카드 형태로 변경
- [x]  이전 사이트 그래프 만들기
- [x]  click 키워드 그래프 만들기
- [x]  click 태그 그래프 만들기
