### PR TITLE
[2022.11.20] 비디오 페이지 레이아웃

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.10.6",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sa-ux-test-client",
-      "version": "0.10.6",
+      "version": "0.11.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sa-ux-test-client",
-  "version": "0.10.6",
+  "version": "0.11.1",
   "private": true,
   "repository": "https://github.com/comt-mix/sa-ux-test-client.git",
   "author": "Sang-a Lee <comt-mix@gmail.com>",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,6 +5,7 @@ import Projects from "../pages/Projects";
 import CreateProject from "../components/Projects/CreateProject";
 import DeleteProject from "../components/Projects/DeleteProject";
 import Dashboard from "../pages/Dashboard";
+import Recording from "../pages/Recording";
 
 const App = () => {
   return (
@@ -14,6 +15,7 @@ const App = () => {
       <Route path="/projects/new" element={<CreateProject />} />
       <Route path="/projects/:id/delete" element={<DeleteProject />} />
       <Route path="/tests/:id/dashboard" element={<Dashboard />} />
+      <Route path="/tests/:id/recording" element={<Recording />} />
     </Routes>
   );
 };

--- a/src/components/Statics/Video.js
+++ b/src/components/Statics/Video.js
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const Video = () => {
+  const [video, setVideo] = useState(null);
+
+  const handleChangeVideo = (event) => {
+    setVideo(URL.createObjectURL(event.target.files[0]));
+  };
+
+  return (
+    <Wrapper>
+      <LeftSide>
+        <input type="file" onChange={handleChangeVideo} />
+      </LeftSide>
+      <RightSide>
+        <iframe
+          src={video}
+          width="100%"
+          height="650"
+          frameBorder="0"
+          scrolling="no"
+          allow="accelerometer; autoplay; clipboard-write;"
+          allowFullScreen
+        ></iframe>
+      </RightSide>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 1rem;
+`;
+
+const LeftSide = styled.div`
+  float: left;
+  width: 25%;
+`;
+
+const RightSide = styled.div`
+  float: right;
+  width: 75%;
+  height: 100%;
+`;
+
+export default Video;

--- a/src/pages/Recording.js
+++ b/src/pages/Recording.js
@@ -1,0 +1,16 @@
+import React from "react";
+import Header from "../components/Header/Header";
+import Navbar from "../components/Header/Navbar";
+import Video from "../components/Statics/Video";
+
+const Recording = () => {
+  return (
+    <>
+      <Header />
+      <Navbar />
+      <Video />
+    </>
+  );
+};
+
+export default Recording;


### PR DESCRIPTION
<img width="1512" alt="비디오 페이지" src="https://user-images.githubusercontent.com/89302818/202893526-a6477a77-3ce0-4d3c-8271-d25406734be8.png">

# Topic
- 비디오 페이지 레이아웃 구현

# Detail
- 비디오 페이지 레이아웃 구현
- 비디오 영상 재생하는 것까지 구현

# Kanban Link
- https://shaded-calculator-f57.notion.site/Layout-38d44383321348788d46f29a82df1d53

# Kanban List
- [x]  비디오 영상가져와서 띄우기
